### PR TITLE
Update resources/skins/default/720p/script.pseudotv.ChannelConfig.xml

### DIFF
--- a/resources/skins/default/720p/script.pseudotv.ChannelConfig.xml
+++ b/resources/skins/default/720p/script.pseudotv.ChannelConfig.xml
@@ -10,7 +10,7 @@
 
     <controls>
         <control type="image">
-            <posx>340</posx>
+            <posx>30</posx>
             <posy>100</posy>
             <width>600</width>
             <height>520</height>
@@ -20,7 +20,7 @@
         </control>
 
         <control type="image">
-            <posx>465</posx>
+            <posx>145</posx>
             <posy>125</posy>
             <width>350</width>
             <height>85</height>
@@ -29,7 +29,7 @@
         </control>
 
         <control type="label">
-            <posx>340</posx>
+            <posx>20</posx>
             <posy>130</posy>
             <width>600</width>
             <height>40</height>
@@ -41,7 +41,7 @@
         </control>
 
         <control type="label">
-            <posx>340</posx>
+            <posx>20</posx>
             <posy>170</posy>
             <width>600</width>
             <height>30</height>
@@ -53,7 +53,7 @@
         </control>
 
         <control type="group" id="105">
-            <posx>340</posx>
+            <posx>20</posx>
             <posy>220</posy>
             <width>600</width>
             <height>400</height>
@@ -188,7 +188,7 @@
 
         <!-- Controls for configuring a single channel -->
         <control type="group" id="106">
-            <posx>340</posx>
+            <posx>20</posx>
             <posy>220</posy>
             <width>600</width>
             <height>400</height>
@@ -225,7 +225,7 @@
             </control>
 
             <control type="label" id="109">
-                <posx>480</posx>
+                <posx>160</posx>
                 <posy>60</posy>
                 <width>270</width>
                 <height>30</height>
@@ -258,7 +258,7 @@
             </control>
             
             <control type="button" id="114">
-                <posx>60</posx>
+                <posx>160</posx>
                 <posy>260</posy>
                 <width>300</width>
                 <height>30</height>
@@ -305,7 +305,7 @@
         <control type="group" id="107">
             <!-- Controls for type Custom Playlist -->
             <control type="group" id="120">
-                <posx>340</posx>
+                <posx>20</posx>
                 <posy>220</posy>
                 <width>600</width>
                 <height>400</height>
@@ -334,7 +334,7 @@
     
             <!-- Controls for type TV Network -->
             <control type="group" id="121">
-                <posx>340</posx>
+                <posx>20</posx>
                 <posy>220</posy>
                 <width>600</width>
                 <height>400</height>
@@ -351,7 +351,7 @@
                 </control>
     
                 <control type="label" id="142">
-                    <posx>480</posx>
+                    <posx>160</posx>
                     <posy>100</posy>
                     <width>270</width>
                     <height>30</height>
@@ -390,7 +390,7 @@
     
             <!-- Controls for type Movie Studio -->
             <control type="group" id="122">
-                <posx>340</posx>
+                <posx>20</posx>
                 <posy>220</posy>
                 <width>600</width>
                 <height>400</height>
@@ -407,7 +407,7 @@
                 </control>
     
                 <control type="label" id="152">
-                    <posx>480</posx>
+                    <posx>160</posx>
                     <posy>100</posy>
                     <width>270</width>
                     <height>30</height>
@@ -446,7 +446,7 @@
     
             <!-- Controls for type TV Genre -->
             <control type="group" id="123">
-                <posx>340</posx>
+                <posx>20</posx>
                 <posy>220</posy>
                 <width>600</width>
                 <height>400</height>
@@ -463,7 +463,7 @@
                 </control>
     
                 <control type="label" id="162">
-                    <posx>480</posx>
+                    <posx>160</posx>
                     <posy>100</posy>
                     <width>270</width>
                     <height>30</height>
@@ -502,7 +502,7 @@
     
             <!-- Controls for type Movie Genre -->
             <control type="group" id="124">
-                <posx>340</posx>
+                <posx>20</posx>
                 <posy>220</posy>
                 <width>600</width>
                 <height>400</height>
@@ -519,7 +519,7 @@
                 </control>
     
                 <control type="label" id="172">
-                    <posx>480</posx>
+                    <posx>160</posx>
                     <posy>100</posy>
                     <width>270</width>
                     <height>30</height>
@@ -558,7 +558,7 @@
     
             <!-- Controls for type Mixed Genre -->
             <control type="group" id="125">
-                <posx>340</posx>
+                <posx>20</posx>
                 <posy>220</posy>
                 <width>600</width>
                 <height>400</height>
@@ -575,7 +575,7 @@
                 </control>
     
                 <control type="label" id="182">
-                    <posx>480</posx>
+                    <posx>160</posx>
                     <posy>100</posy>
                     <width>270</width>
                     <height>30</height>
@@ -614,7 +614,7 @@
     
             <!-- Controls for type TV Show -->
             <control type="group" id="126">
-                <posx>340</posx>
+                <posx>20</posx>
                 <posy>220</posy>
                 <width>600</width>
                 <height>400</height>
@@ -631,7 +631,7 @@
                 </control>
     
                 <control type="label" id="192">
-                    <posx>480</posx>
+                    <posx>160</posx>
                     <posy>100</posy>
                     <width>270</width>
                     <height>30</height>
@@ -691,7 +691,7 @@
     
             <!-- Controls for type Directory -->
             <control type="group" id="127">
-                <posx>340</posx>
+                <posx>20</posx>
                 <posy>220</posy>
                 <width>600</width>
                 <height>400</height>


### PR DESCRIPTION
Adjusted ChannelConfig.xml to match recommendations from http://justpaste.it/1gce to resolve ChannelConfig window going off-screen as in issue #26: https://github.com/Jasonra/XBMC-PseudoTV/issues/26

Thanks to Karrade: https://github.com/Karrade for pointing me in the right direction on a fix.
