### PR TITLE
Enhanced interleaving rule

### DIFF
--- a/resources/lib/Rules.py
+++ b/resources/lib/Rules.py
@@ -30,7 +30,7 @@ from Playlist import PlaylistItem
 
 class RulesList:
     def __init__(self):
-        self.ruleList = [BaseRule(), ScheduleChannelRule(), HandleChannelLogo(), NoShowRule(), DontAddChannel(), ForceRandom(), ForceRealTime(), ForceResume(), HandleIceLibrary(), InterleaveChannel(), OnlyUnWatchedRule(), OnlyWatchedRule(), AlwaysPause(), PlayShowInOrder(), RenameRule(), SetResetTime()]
+        self.ruleList = [BaseRule(), ScheduleChannelRule(), HandleChannelLogo(), NoShowRule(), DontAddChannel(), EvenShowsRule(), ForceRandom(), ForceRealTime(), ForceResume(), HandleIceLibrary(), InterleaveChannel(), OnlyUnWatchedRule(), OnlyWatchedRule(), AlwaysPause(), PlayShowInOrder(), RenameRule(), SetResetTime()]
 
 
     def getRuleCount(self):
@@ -944,8 +944,8 @@ class DontAddChannel(BaseRule):
 class InterleaveChannel(BaseRule):
     def __init__(self):
         self.name = "Interleave Another Channel"
-        self.optionLabels = ['Channel Number', 'Min Interleave Count', 'Max Interleave Count', 'Starting Episode']
-        self.optionValues = ['0', '1', '1', '1']
+        self.optionLabels = ['Channel Number', 'Min Interleave Count', 'Max Interleave Count', 'Starting Episode', 'Play # Episodes', 'Start Position']
+        self.optionValues = ['0', '1', '1', '1', '1', '1']
         self.myId = 6
         self.actions = RULES_ACTION_LIST
 
@@ -972,6 +972,8 @@ class InterleaveChannel(BaseRule):
         self.validateDigitBox(1, 1, 100, 1)
         self.validateDigitBox(2, 1, 100, 1)
         self.validateDigitBox(3, 1, 10000, 1)
+        self.validateDigitBox(4, 1, 10000, 1)
+        self.validateDigitBox(5, 1, 1, 1)
 
 
     def runAction(self, actionid, channelList, filelist):
@@ -981,6 +983,8 @@ class InterleaveChannel(BaseRule):
             minint = 0
             maxint = 0
             startingep = 0
+            numbereps = 0
+            startfrom = 1
             curchan = channelList.runningActionChannel
             curruleid = channelList.runningActionId
             self.validate()
@@ -990,10 +994,13 @@ class InterleaveChannel(BaseRule):
                 minint = int(self.optionValues[1])
                 maxint = int(self.optionValues[2])
                 startingep = int(self.optionValues[3])
+                numbereps = int(self.optionValues[4])
+                startfrom = int(self.optionValues[5])
+
             except:
                 self.log("Except when reading params")
 
-            if chan > channelList.maxChannels or chan < 1 or minint < 1 or maxint < 1 or startingep < 1:
+            if chan > channelList.maxChannels or chan < 1 or minint < 1 or maxint < 1 or startingep < 1 or numbereps < 1:
                 return filelist
 
             if minint > maxint:
@@ -1011,11 +1018,20 @@ class InterleaveChannel(BaseRule):
                 self.log("The target channel is empty")
                 return filelist
 
+            if startfrom > 0:
+                startfrom = 1
+            else:
+                startfrom = 0
+
+            startfrom -= 1
+            
             realindex = random.randint(minint, maxint)
             startindex = 0
             # Use more memory, but greatly speed up the process by just putting everything into a new list
             newfilelist = []
             self.log("Length of original list: " + str(len(filelist)))
+
+            realindex += startfrom
 
             while realindex < len(filelist):
                 if channelList.threadPause() == False:
@@ -1025,13 +1041,18 @@ class InterleaveChannel(BaseRule):
                     newfilelist.append(filelist[startindex])
                     startindex += 1
 
-                newstr = str(channelList.channels[chan - 1].getItemDuration(startingep - 1)) + ',' + channelList.channels[chan - 1].getItemTitle(startingep - 1)
-                newstr += "//" + channelList.channels[chan - 1].getItemEpisodeTitle(startingep - 1)
-                newstr += "//" + channelList.channels[chan - 1].getItemDescription(startingep - 1) + '\n' + channelList.channels[chan - 1].getItemFilename(startingep - 1)
-                newfilelist.append(newstr)
+                # Added FOR loop to iterate interleaving multiple-continuous episodes from chosen channel
+                for i in range(numbereps):
+                    newstr = str(channelList.channels[chan - 1].getItemDuration(startingep - 1)) + ',' + channelList.channels[chan - 1].getItemTitle(startingep - 1)
+                    newstr += "//" + channelList.channels[chan - 1].getItemEpisodeTitle(startingep - 1)
+                    newstr += "//" + channelList.channels[chan - 1].getItemDescription(startingep - 1) + '\n' + channelList.channels[chan - 1].getItemFilename(startingep - 1)
+                    newfilelist.append(newstr)
+                    # Moved startingep to FOR loop - otherwise it just adds the same file multiple times
+                    startingep += 1
+                    
                 realindex += random.randint(minint, maxint)
-                startingep += 1
-
+                
+    
             while startindex < len(filelist):
                 newfilelist.append(filelist[startindex])
                 startindex += 1
@@ -1433,4 +1454,101 @@ class HandleChannelLogo(BaseRule):
             self.log("set channel bug to " + str(overlay.showChannelBug))
 
         return channeldata
+
+
+
+class EvenShowsRule(BaseRule):
+    def __init__(self):
+        self.name = "Even Show Distribution"
+        self.optionLabels = ['Same Show Eps in a Row']
+        self.optionValues = ['2']
+        self.myId = 16
+        self.actions = RULES_ACTION_LIST
+
+
+    def copy(self):
+        return EvenShowsRule()
+
+
+    def getTitle(self):
+        return self.name
+
+
+    def onAction(self, act, optionindex):
+        self.onActionDigitBox(act, optionindex)
+        self.validate()
+        return self.optionValues[optionindex]
+
+
+    def validate(self):
+        self.validateDigitBox(0, 1, 20, 1)
+
+
+    def runAction(self, actionid, channelList, filelist):
+        if actionid == RULES_ACTION_LIST:
+            self.validate()
+            
+            try:
+                opt = int(self.optionValues[0])
+                self.log("Allowed shows in a row: " + str(opt))
+                lastshow = ''
+                realindex = 0
+                inarow = 0
+
+                for index in range(len(filelist)):
+                    item = filelist[index]
+                    self.log("index " + str(index) + " is " + item)
+                    loc = item.find(',')
+
+                    if loc > -1:
+                        loc2 = item.find("//")
+
+                        if loc2 > -1:
+                            showname = item[loc + 1:loc2]
+                            showname = showname.lower()
+
+                            if showname == lastshow:
+                                inarow += 1
+                                self.log("same show now at " + str(inarow))
+                                
+                                if inarow >= opt:
+                                    nextline = self.insertNewShow(filelist, lastshow, index)
+                                    
+                                    if nextline == '':
+                                        filelist = filelist[:index]
+                                        return filelist
+                                    else:
+                                        filelist.insert(index, nextline)
+                                        lastshow = ''
+                            else:
+                                lastshow = showname
+                                self.log("new show: " + lastshow)
+                                inarow = 0
+            except:
+                pass
+
+        return filelist
+        
+        
+    def insertNewShow(self, filelist, lastshow, startindex):
+        self.log("insertNewShow: " + str(startindex) + ", " + str(len(filelist)))
+        for index in range(startindex + 1, len(filelist)):
+            item = filelist[index]
+            self.log("insertNewShow index " + str(index) + " is " + item)
+            loc = item.find(',')
+
+            if loc > -1:
+                loc2 = item.find("//")
+
+                if loc2 > -1:
+                    showname = item[loc + 1:loc2]
+                    showname = showname.lower()
+
+                    if showname != lastshow:
+                        self.log("insertNewShow found " + showname)
+                        filelist.pop(index)
+                        return item
+                        
+        return ''
+
 


### PR DESCRIPTION
Added two options to the Interleave rules. "Play # Episodes" Allows you to interleave multiple episodes from the channel being interleaved, instead of being restricted to interleaving one episode at a time.

Previous function:

(assuming interleaving ch.2 into ch.1)

Min = 1 / Max = 1 : 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2

Min = 2 / Max = 2 : 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2

Min = 3 / Max = 3 : 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 2

New function:

Min = 1 / Max = 1 / Episodes = 1: 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2

Min = 1 / Max = 1 / Episodes = 2: 1, 2, 2, 1, 2, 2, 1, 2, 2, 1, 2, 2

Min = 3 / Max = 3 / Episodes = 2: 1, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1, 1, 1, 2, 2

"Starting Position" option. This changes where the channel starts interleaving. A value of "1" (default) acts the same as current functionality. Beginning interleaving AFTER the first episode of the base channel. A value of "0" will begin interleaving BEFORE the first episode of the base channel.

Previous Function:

Min = 1 / Max = 1 : 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2

New Function:

Min = 1 / Max = 1 / Episodes = 1 / Start = 1: 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2

Min = 1 / Max = 1 / Episodes = 1 / Start = 0: 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1
